### PR TITLE
update library search term for better results

### DIFF
--- a/lib/library_assistant/islington_library.rb
+++ b/lib/library_assistant/islington_library.rb
@@ -14,7 +14,7 @@ module LibraryAssistant
     end
 
     def initialize(title, author)
-      @title = title
+      @title = title.split(": ").first
       @author = author
     end
 
@@ -30,7 +30,7 @@ module LibraryAssistant
 
     def search_url_with_query
       uri = Addressable::URI.parse(BASE_SEARCH_URL)
-      uri.query_values = {query: "#{@title} AND author:(#{@author}) AND format:(book)"}
+      uri.query_values = {query: "#{@title} #{@author} AND format:(book)"}
       uri.to_s
     end
   end

--- a/spec/fixtures/islington_library_query_results/two_items.xml
+++ b/spec/fixtures/islington_library_query_results/two_items.xml
@@ -6,16 +6,16 @@
   xmlns:dcterms="http://purl.org/dc/terms/"
   xmlns:bibo="http://purl.org/ontology/bibo/">
 
-  <rss:channel rdf:about="https://capitadiscovery.co.uk/islington/items.rss?query=The%20Martian%20AND%20author%3A%28Andy%20Weir%29%20AND%20format%3A%28book%29">
-    <rss:link rdf:resource="https://capitadiscovery.co.uk/islington/items.rss?query=The%20Martian%20AND%20author%3A%28Andy%20Weir%29%20AND%20format%3A%28book%29" />
-    <rss:title>Search results for The Martian AND author:(Andy Weir...</rss:title>
+  <rss:channel rdf:about="https://capitadiscovery.co.uk/islington/items.rss?query=The%20Martian%20Andy%20Weir%20AND%20format%3A%28book%29">
+    <rss:link rdf:resource="https://capitadiscovery.co.uk/islington/items.rss?query=The%20Martian%20Andy%20Weir%20AND%20format%3A%28book%29" />
+    <rss:title>Search results for The Martian Andy Weir AND format:(book)</rss:title>
     <os:startIndex>0</os:startIndex>
     <os:itemsPerPage>10</os:itemsPerPage>
     <os:totalResults>2</os:totalResults>
-    <rss:items rdf:resource="urn:uuid:10d61545-26ac-595e-97b9-32bcdb6f9569" />
+    <rss:items rdf:resource="urn:uuid:c2ba3a7e-71a6-5fe3-959a-48a72d9ec106" />
   </rss:channel>
 
-  <rdf:Seq rdf:about="urn:uuid:10d61545-26ac-595e-97b9-32bcdb6f9569">
+  <rdf:Seq rdf:about="urn:uuid:c2ba3a7e-71a6-5fe3-959a-48a72d9ec106">
     <rdf:_1 rdf:resource="http://capitadiscovery.co.uk/islington/items/872958" />
     <rdf:_2 rdf:resource="http://capitadiscovery.co.uk/islington/items/829265" />
   </rdf:Seq>

--- a/spec/fixtures/islington_library_query_results/zero_items.xml
+++ b/spec/fixtures/islington_library_query_results/zero_items.xml
@@ -3,16 +3,16 @@
   xmlns:rss="http://purl.org/rss/1.0/"
   xmlns:os="http://a9.com/-/spec/opensearch/1.1/">
 
-  <rss:channel rdf:about="https://capitadiscovery.co.uk/islington/items.rss?query=The%20Saturnian%20AND%20author%3A%28Andy%20Weir%29%20AND%20format%3A%28book%29">
-    <rss:link rdf:resource="https://capitadiscovery.co.uk/islington/items.rss?query=The%20Saturnian%20AND%20author%3A%28Andy%20Weir%29%20AND%20format%3A%28book%29" />
-    <rss:title>Search results for The Saturnian AND author:(Andy...</rss:title>
+  <rss:channel rdf:about="https://capitadiscovery.co.uk/islington/items.rss?query=The%20Saturnian%20Andy%20Weir%20AND%20format%3A%28book%29">
+    <rss:link rdf:resource="https://capitadiscovery.co.uk/islington/items.rss?query=The%20Saturnian%20Andy%20Weir%20AND%20format%3A%28book%29" />
+    <rss:title>Search results for The Saturnian Andy Weir AND format:(book)</rss:title>
     <os:startIndex>0</os:startIndex>
     <os:itemsPerPage>10</os:itemsPerPage>
     <os:totalResults>0</os:totalResults>
-    <rss:items rdf:resource="urn:uuid:1653de6d-7fc4-533f-b930-9717080e8a4a" />
+    <rss:items rdf:resource="urn:uuid:c6a90202-de0a-5452-ac69-cc33a339e5a8" />
   </rss:channel>
 
-  <rdf:Seq rdf:about="urn:uuid:1653de6d-7fc4-533f-b930-9717080e8a4a">
+  <rdf:Seq rdf:about="urn:uuid:c6a90202-de0a-5452-ac69-cc33a339e5a8">
   </rdf:Seq>
 
 </rdf:RDF>

--- a/spec/library_assistant/islington_library_spec.rb
+++ b/spec/library_assistant/islington_library_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe LibraryAssistant::IslingtonLibrary do
+  describe "#initialize" do
+    subject { described_class.new(title, "Author") }
+
+    context "when the title has a 'subtitle'" do
+      let(:title) { "Testosterone Rex: Unmaking the Myths of Our Gendered Minds" }
+
+      it "strips the 'subtitle' from the title" do
+        expect(subject.instance_variable_get(:@title)).to eq("Testosterone Rex")
+      end
+    end
+
+    context "when the title does not have a 'subtitle'" do
+      let(:title) { "The Martian" }
+
+      it "leaves the title as it is" do
+        expect(subject.instance_variable_get(:@title)).to eq("The Martian")
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've noticed that the Islington Library returns terribly wrong results sometimes.

- When the title looks something like "This is the Main Idea: Here are some more words about it", removing everything that comes after the colon seems to help.
- Searching for "[Title] [Author]" seems to work better than "[Title] AND author:([Author])".

Examples:
1. **BEFORE**, lots we don't want among the one we do want: https://capitadiscovery.co.uk/islington/items?query=Home+AND+author%3A%28Amanda+Berriman%29+AND+format%3A%28book%29
**AFTER**, just the one we want: 
https://capitadiscovery.co.uk/islington/items?query=Home+Amanda+Berriman+AND+format%3A%28book%29
2. **BEFORE**, nothing we actually want: 
https://capitadiscovery.co.uk/islington/items.rss?query=Book%20of%20Peoples%20of%20the%20World%3A%20A%20Guide%20to%20Cultures%20AND%20author%3A%28Wade%20Davis%29%20AND%20format%3A%28book%29
**AFTER**, simply 0 results: 
https://capitadiscovery.co.uk/islington/items.rss?query=Book%20of%20Peoples%20of%20the%20World%20Wade%20Davis%29%20AND%20format%3A%28book%29 

Note: The BEFORE in (2) was what spec/fixtures/islington_library_query_results/zero_items.xml referenced. The "AND format:(book)" filtering might work better with the updated search term, but I'm keeping our non-book filtering of the results for now.