### PR TITLE
Rethink library result to clearly show 3 states

### DIFF
--- a/lib/library_assistant.rb
+++ b/lib/library_assistant.rb
@@ -7,10 +7,10 @@ module LibraryAssistant
     found = false
 
     result = Goodreads.generate_book_requests.each do |request|
-      request.library_result = IslingtonLibrary.search(title: request.title, author: request.author)
+      request.library_search_result = IslingtonLibrary.search(title: request.title, author: request.author)
 
-      if found = request.found?
-        break request.library_result
+      if found = request.book_found?
+        break request.library_search_result.book
       end
     end
 

--- a/lib/library_assistant/book_request.rb
+++ b/lib/library_assistant/book_request.rb
@@ -8,7 +8,8 @@ module LibraryAssistant
       @library_result = nil
     end
 
-    attr_accessor :title, :author, :image_url, :average_rating, :library_result
+    attr_reader :title, :author, :image_url, :average_rating
+    attr_accessor :library_result
 
     def found?
       @library_result.present?

--- a/lib/library_assistant/book_request.rb
+++ b/lib/library_assistant/book_request.rb
@@ -5,14 +5,16 @@ module LibraryAssistant
       @author = author
       @image_url = image_url
       @average_rating = average_rating
-      @library_result = nil
+      @library_search_result = nil
     end
 
     attr_reader :title, :author, :image_url, :average_rating
-    attr_accessor :library_result
+    attr_accessor :library_search_result
 
-    def found?
-      @library_result.present?
+    def book_found?
+      return false unless @library_search_result
+
+      @library_search_result.book?
     end
   end
 end

--- a/lib/library_assistant/islington_library.rb
+++ b/lib/library_assistant/islington_library.rb
@@ -1,7 +1,7 @@
 require "nokogiri"
 require "addressable"
 require "open-uri"
-require "library_assistant/islington_library/query_result"
+require "library_assistant/islington_library/query_result_interpreter"
 
 module LibraryAssistant
   class IslingtonLibrary
@@ -19,7 +19,7 @@ module LibraryAssistant
     end
 
     def search_result
-      QueryResult.new(parsed_query_result_xml).book
+      QueryResultInterpreter.new(parsed_query_result_xml).result
     end
 
     private

--- a/lib/library_assistant/islington_library/query_result_interpreter.rb
+++ b/lib/library_assistant/islington_library/query_result_interpreter.rb
@@ -1,22 +1,25 @@
+require "library_assistant/library_search_result"
 require "library_assistant/islington_library/book"
 
 module LibraryAssistant
   class IslingtonLibrary
-    class QueryResult
+    class QueryResultInterpreter
       def initialize(parsed_query_result_xml)
         @doc = parsed_query_result_xml
 
         filter_to_books_only
       end
 
-      def book
-        return nil unless any?
+      def result
+        return LibrarySearchResult.new unless any?
 
-        Book.new(
-          title: value_for_newest_item("rss:title"),
-          author: value_for_newest_item("dc:creator"),
-          year: value_for_newest_item("dc:date"),
-          link: value_for_newest_item("rss:link")
+        LibrarySearchResult.new(
+          Book.new(
+            title: value_for_newest_item("rss:title"),
+            author: value_for_newest_item("dc:creator"),
+            year: value_for_newest_item("dc:date"),
+            link: value_for_newest_item("rss:link")
+          )
         )
       end
 

--- a/lib/library_assistant/library_search_result.rb
+++ b/lib/library_assistant/library_search_result.rb
@@ -1,0 +1,13 @@
+module LibraryAssistant
+  class LibrarySearchResult
+    def initialize(book = nil)
+      @book = book
+    end
+
+    attr_reader :book
+
+    def book?
+      book.present?
+    end
+  end
+end

--- a/spec/library_assistant/book_request_spec.rb
+++ b/spec/library_assistant/book_request_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe LibraryAssistant::BookRequest do
+  describe "#book_found?" do
+    let(:book_request) do
+      described_class.new(
+        title: Object.new, author: Object.new,
+        image_url: Object.new, average_rating: Object.new
+      )
+    end
+
+    before { book_request.library_search_result = library_search_result }
+
+    subject { book_request.book_found? }
+
+    context "when library_search_result is nil" do
+      let(:library_search_result) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when library_search_result is present" do
+      let(:library_search_result) { LibraryAssistant::LibrarySearchResult.new }
+
+      context "when the result has a book" do
+        before do
+          allow(library_search_result).to receive(:book?).and_return(true)
+        end
+
+        it { is_expected.to be_truthy }
+      end
+
+      context "when the result does not have a book" do
+        before do
+          allow(library_search_result).to receive(:book?).and_return(false)
+        end
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+end

--- a/spec/library_assistant/islington_library/query_result_interpreter_spec.rb
+++ b/spec/library_assistant/islington_library/query_result_interpreter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe LibraryAssistant::IslingtonLibrary::QueryResult do
+RSpec.describe LibraryAssistant::IslingtonLibrary::QueryResultInterpreter do
   subject { described_class.new(parsed_query_result_xml) }
 
   let(:parsed_query_result_xml) do
@@ -14,25 +14,25 @@ RSpec.describe LibraryAssistant::IslingtonLibrary::QueryResult do
     end
   end
 
-  describe "#book" do
+  describe "#result" do
     context "when there are book items" do
       let(:query_result_file_path) { "../../fixtures/islington_library_query_results/two_items.xml" }
 
       it "returns the newer book" do
-        book = described_class.new(parsed_query_result_xml).book
+        result = described_class.new(parsed_query_result_xml).result
 
-        expect(book.year).to eq("2015")
-        expect(book.link).to eq("http://capitadiscovery.co.uk/islington/items/872958")
+        expect(result.book.year).to eq("2015")
+        expect(result.book.link).to eq("http://capitadiscovery.co.uk/islington/items/872958")
       end
     end
 
     context "when there are no book items" do
       let(:query_result_file_path) { "../../fixtures/islington_library_query_results/zero_items.xml" }
 
-      it "returns nil" do
-        book = described_class.new(parsed_query_result_xml).book
+      it "returns a result with no book" do
+        result = described_class.new(parsed_query_result_xml).result
 
-        expect(book).to be_nil
+        expect(result.book).to be_nil
       end
     end
   end

--- a/spec/library_assistant_spec.rb
+++ b/spec/library_assistant_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe LibraryAssistant do
       allow(described_class::Goodreads).to receive(:generate_book_requests).
         and_return(book_requests)
       allow(described_class::IslingtonLibrary).to receive(:search).
-        with(title: book_requests[0].title, author: book_requests[0].author).and_return(nil)
+        with(title: book_requests[0].title, author: book_requests[0].author).
+        and_return(described_class::LibrarySearchResult.new)
       allow(described_class::IslingtonLibrary).to receive(:search).
-        with(title: book_requests[1].title, author: book_requests[1].author).and_return(expected_book)
+        with(title: book_requests[1].title, author: book_requests[1].author).
+        and_return(described_class::LibrarySearchResult.new(expected_book))
     end
 
     it "returns the first book from the Goodreads shelf that is available from the library" do


### PR DESCRIPTION
...the 3 states being (i) not searched yet, (ii) searched and got a book back, and (iii) searched and got nothing.

There is now an actual `LibrarySearchResult` that gets returned after a search, which responds to a `book?` method so that we can tell whether the search comes back with a book or not.

Also done some renaming to make things clearer.