### PR TITLE
Use FactoryBot and Faker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,10 @@ GEM
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.1)
+    factory_bot (4.8.2)
+      activesupport (>= 3.0.0)
+    faker (1.8.7)
+      i18n (>= 0.7)
     goodreads (0.6.1)
       activesupport (>= 3.0)
       hashie (~> 2.0)
@@ -73,6 +77,8 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  factory_bot (~> 4.0)
+  faker
   library_assistant!
   rake (~> 10.0)
   rspec (~> 3.0)

--- a/library_assistant.gemspec
+++ b/library_assistant.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "factory_bot", "~> 4.0"
+  spec.add_development_dependency "faker"
 
   spec.add_runtime_dependency "dotenv"
   spec.add_runtime_dependency "addressable"

--- a/spec/factories/islington_library/book.rb
+++ b/spec/factories/islington_library/book.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :islington_library_book, class: LibraryAssistant::IslingtonLibrary::Book do
+    title { Faker::Book.title }
+    author { Faker::Book.author }
+    year { rand(1900..2018) }
+    link { Faker::Internet.url }
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/factories/library_assistant/book_request.rb
+++ b/spec/factories/library_assistant/book_request.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :book_request, class: LibraryAssistant::BookRequest do
+    title { Faker::Book.title }
+    author { Faker::Book.author }
+    image_url { Faker::Internet.url }
+    average_rating { rand(3.0..5.0).round(2) }
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/spec/factories/library_assistant/library_search_result.rb
+++ b/spec/factories/library_assistant/library_search_result.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :library_search_result, class: LibraryAssistant::LibrarySearchResult do
+    trait :without_book do
+    end
+
+    trait :with_book do
+      initialize_with { new(build(:islington_library_book)) }
+    end
+  end
+end

--- a/spec/library_assistant/book_request_spec.rb
+++ b/spec/library_assistant/book_request_spec.rb
@@ -1,11 +1,6 @@
 RSpec.describe LibraryAssistant::BookRequest do
   describe "#book_found?" do
-    let(:book_request) do
-      described_class.new(
-        title: Object.new, author: Object.new,
-        image_url: Object.new, average_rating: Object.new
-      )
-    end
+    let(:book_request) { build(:book_request) }
 
     before { book_request.library_search_result = library_search_result }
 
@@ -18,20 +13,14 @@ RSpec.describe LibraryAssistant::BookRequest do
     end
 
     context "when library_search_result is present" do
-      let(:library_search_result) { LibraryAssistant::LibrarySearchResult.new }
-
       context "when the result has a book" do
-        before do
-          allow(library_search_result).to receive(:book?).and_return(true)
-        end
+        let(:library_search_result) { build(:library_search_result, :with_book) }
 
         it { is_expected.to be_truthy }
       end
 
       context "when the result does not have a book" do
-        before do
-          allow(library_search_result).to receive(:book?).and_return(false)
-        end
+        let(:library_search_result) { build(:library_search_result) }
 
         it { is_expected.to be_falsey }
       end

--- a/spec/library_assistant_spec.rb
+++ b/spec/library_assistant_spec.rb
@@ -4,13 +4,7 @@ RSpec.describe LibraryAssistant do
   end
 
   describe ".grab_a_book" do
-    let(:book_requests) do
-      [
-        described_class::BookRequest.new(title: "A", author: "B", image_url: "C", average_rating: "D"),
-        described_class::BookRequest.new(title: "H", author: "I", image_url: "J", average_rating: "K"),
-        described_class::BookRequest.new(title: "W", author: "X", image_url: "Y", average_rating: "Z")
-      ]
-    end
+    let(:book_requests) { build_list(:book_request, 3) }
 
     let(:expected_book) do
       described_class::IslingtonLibrary::Book.new(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "library_assistant"
+require "support/factory_bot"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,10 @@
+require "factory_bot"
+require "faker"
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
+end


### PR DESCRIPTION
What it says on the tin. It's getting tiresome creating objects manually when there are all those namespaces.

Also, never used FactoryBot without Rails before, so TIL:

> For maximum compatibility with ActiveRecord, the default initializer builds all instances by calling new on your build class without any arguments. It then calls attribute writer methods to assign all the attribute values.
– https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md

For the LibrarySearchResult factory, I'd tried using `trait` and later `transient` to give the object a `book` based on the presence of a `with_book` flag, only to run into the same `undefined method 'book=' for #<LibraryAssistant::LibrarySearchResult:0x007fcc85863388>` error. It felt wrong to have to change the code to have write access for the spec, so I looked harder and figured it out. 😄 