### PR TITLE
Allow a desired book count to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LibraryAssistant ![](https://travis-ci.org/maloneyl/library_assistant.svg?branch=master)
 
-This is a little pet project that helps me manage my reading and gives me something to experiment with. 
+This is a little pet project that helps me manage my reading and gives me something to experiment with.
 
 I read a lot and get almost all of my books from the library. As much as I love my local library (hi, Islington 👋🏽), its website leaves a lot to be desired. It was also getting a bit silly how often I'd look up a book on both Goodreads (to check reviews and add to my to-read shelf) and the library catalogue (to see if the book's even stocked), so I thought I should try to automate that process.
 
@@ -22,13 +22,17 @@ Or install it yourself as:
 
 ## Usage
 
-See `.env.example` for the required `.env` setup.
+See `.env.example` for the required `.env` setup. The Goodreads credentials involved are an API key, a user ID, and the name of a shelf associated with that user ID.
 
 All `LibraryAssistant` methods involve first getting the most recently added books (up to 20) on the Goodreads shelf specified in your `.env`:
 
-* `LibraryAssistant.grab_a_book` returns the first book found in the Islington library catalogue (see [library-assistant-cli](https://github.com/maloneyl/library-assistant-cli) for how I use it, which was how this project started). 
+* `LibraryAssistant.grab_a_book` returns the first book found in the Islington library catalogue. See [library-assistant-cli](https://github.com/maloneyl/library-assistant-cli) for how I use it, which was how this project started.
 
-* `LibraryAssistant.generate_and_handle_book_requests` returns processed book requests with their library search results. Calling the method with `filter: true` filters the book requests to those with positive search results (see [library-assistant-web](https://github.com/maloneyl/library-assistant-web) for an example).
+* `LibraryAssistant.generate_and_process_book_requests` returns processed book requests with their library search results. By default, only the ones with books found are returned. You can pass the method the following options:
+
+  * `include_all: true`: To get back all processed book requests, including ones with bookless search results.
+
+  * `desired_book_count: {number}`: To _attempt_ to get at least that many processed book requests with library books found, looking beyond the first 20 Goodsreads books if needed. See [library-assistant-web](https://github.com/maloneyl/library-assistant-web) for an example.
 
 ## Development
 

--- a/lib/library_assistant/goodreads.rb
+++ b/lib/library_assistant/goodreads.rb
@@ -5,12 +5,14 @@ require "library_assistant/book_request"
 module LibraryAssistant
   class Goodreads
     class << self
-      def get_books_from_shelf
-        client.shelf(ENV["GOODREADS_USER_ID"], ENV["GOODREADS_SHELF_NAME"]).books
+      def get_books_from_shelf(page:)
+        client.shelf(ENV["GOODREADS_USER_ID"], ENV["GOODREADS_SHELF_NAME"], page: page).books
       end
 
-      def generate_book_requests
-        get_books_from_shelf.map { |data| BookRequest.new(extracted_book_data(data)) }
+      def generate_book_requests(page: 1)
+        get_books_from_shelf(page: page).map do |data|
+          BookRequest.new(extracted_book_data(data))
+        end
       end
 
       private

--- a/spec/library_assistant_spec.rb
+++ b/spec/library_assistant_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe LibraryAssistant do
     expect(LibraryAssistant::VERSION).not_to be nil
   end
 
-  shared_context "3 books from Goodreads shelf; last 2 found in Islington Library" do
+  shared_context "5 books from Goodreads shelf; 2nd and 4th found in Islington Library" do
     before do
       allow(described_class).to receive(:generate_book_requests).
-        and_return(book_requests)
+        and_return(book_requests, [])
 
       book_requests.each_with_index do |book_request, i|
         allow(book_request).to receive(:perform_library_search!).
@@ -14,13 +14,15 @@ RSpec.describe LibraryAssistant do
       end
     end
 
-    let(:book_requests) { build_list(:book_request, 3) }
+    let(:book_requests) { build_list(:book_request, 5) }
 
     let(:library_search_results) do
       [
         build(:library_search_result),
         build(:library_search_result, :with_book),
-        build(:library_search_result, :with_book)
+        build(:library_search_result),
+        build(:library_search_result, :with_book),
+        build(:library_search_result)
       ]
     end
 
@@ -32,14 +34,14 @@ RSpec.describe LibraryAssistant do
   end
 
   describe ".grab_a_book" do
-    include_context "3 books from Goodreads shelf; last 2 found in Islington Library"
+    include_context "5 books from Goodreads shelf; 2nd and 4th found in Islington Library"
 
     it "returns the first book from the Goodreads shelf that is available from the library" do
       expect(described_class.grab_a_book).to eq(library_search_results[1].book)
     end
 
     context "when the library doesn't have any of those books" do
-      let(:library_search_results) { build_list(:library_search_result, 3, :without_book) }
+      let(:library_search_results) { build_list(:library_search_result, 5, :without_book) }
 
       it "returns nil" do
         expect(described_class.grab_a_book).to be_nil
@@ -47,29 +49,68 @@ RSpec.describe LibraryAssistant do
     end
   end
 
-  describe ".generate_and_handle_book_requests" do
-    include_context "3 books from Goodreads shelf; last 2 found in Islington Library"
+  describe ".generate_and_process_book_requests" do
+    include_context "5 books from Goodreads shelf; 2nd and 4th found in Islington Library"
 
-    it "creates and handles book requests" do
-      resulting_book_requests = described_class.generate_and_handle_book_requests
+    let(:opts) { {} }
 
-      expect(resulting_book_requests.length).to eq(3)
-      resulting_book_requests.each do |request|
-        expect(request.library_search_result).to be_present
+    subject { described_class.generate_and_process_book_requests(opts) }
+
+    it "creates and processes book requests, returning the ones with books found" do
+      expect(subject.length).to eq(2)
+
+      expect(subject.first.title).to eq(book_requests[1].title)
+      expect(subject.first.library_search_result).to eq(library_search_results[1])
+
+      expect(subject.last.title).to eq(book_requests[3].title)
+      expect(subject.last.library_search_result).to eq(library_search_results[3])
+    end
+
+    context "when called with opts[:include_all]" do
+      let(:opts) { {include_all: true} }
+
+      it "returns all processed book requests" do
+        expect(subject.length).to eq(book_requests.length)
+
+        subject.each do |request|
+          expect(request.library_search_result).to be_present
+        end
       end
     end
 
-    context "when called with filter=true" do
-      it "returns only the ones with books found in the library" do
-        resulting_book_requests = described_class.generate_and_handle_book_requests(filter: true)
+    context "when called with opts[:desired_book_count]" do
+      let(:opts) { {desired_book_count: 2} }
 
-        expect(resulting_book_requests.length).to eq(2)
+      let(:book_requests_from_first_page_of_shelf) { book_requests.first(2) }
+      let(:book_requests_from_second_page_of_shelf) { book_requests.last(2) }
 
-        expect(resulting_book_requests.first.title).to eq(book_requests[1].title)
-        expect(resulting_book_requests.first.library_search_result).to eq(library_search_results[1])
+      it "goes beyond the the first page Goodreads shelf results if needed to reach that book count" do
+        expect(described_class).to receive(:generate_book_requests).
+          and_return(book_requests_from_first_page_of_shelf, book_requests_from_second_page_of_shelf)
 
-        expect(resulting_book_requests.last.title).to eq(book_requests[2].title)
-        expect(resulting_book_requests.last.library_search_result).to eq(library_search_results[2])
+        expect(subject.length).to eq(2)
+      end
+
+      context "when the desired book count cannot be met as we've run out of Goodreads books to try" do
+        let(:opts) { {desired_book_count: 3} }
+
+        it "returns however many that can be found" do
+          expect(described_class).to receive(:generate_book_requests).
+            and_return(book_requests_from_first_page_of_shelf, book_requests_from_second_page_of_shelf, [])
+
+          expect(subject.length).to eq(2)
+        end
+      end
+
+      context "when the desired book count is less than 1" do
+        let(:opts) { {desired_book_count: -1} }
+
+        it "behaves as if this option wasn't given" do
+          expect(described_class).to receive(:generate_book_requests).
+            and_return(book_requests_from_first_page_of_shelf)
+
+          expect(subject.length).to eq(1)
+        end
       end
     end
   end


### PR DESCRIPTION
We've always had this "problem" of not knowing exactly how many books we'd get back from a single `LibraryAssistant.generate_and_process_book_requests` call. Most of the books I've added recently are not in the library catalogue, so I decided it's time to add this functionality.

Notes:
* When we get books from the shelf using the Goodreads gem, we get 20 books a page.
* I've changed `LibraryAssistant.generate_and_process_book_requests`'s default return value from including all book requests (i.e. including ones with no books) to including only the ones with books.
* The recursive `LibraryAssistant.do_work` isn't the best named, but I haven't been able to come up with an alternative, and I figured it's the end of the world if it's only called via the friendlier `LibraryAssistant.generate_and_process_book_requests`. 