### PR TITLE
Consider known `dc:format` values when filtering for books

### DIFF
--- a/lib/library_assistant/islington_library/query_result_interpreter.rb
+++ b/lib/library_assistant/islington_library/query_result_interpreter.rb
@@ -4,6 +4,8 @@ require "library_assistant/islington_library/book"
 module LibraryAssistant
   class IslingtonLibrary
     class QueryResultInterpreter
+      KNOWN_BOOK_FORMATS = ["Book", "Hardback", "Paperback", "Large print"].freeze
+
       def initialize(parsed_query_result_xml)
         @doc = parsed_query_result_xml
 
@@ -29,9 +31,9 @@ module LibraryAssistant
       def filter_to_books_only
         return unless any?
 
-        @doc.xpath("//rss:item/dc:format").each do |node|
-          unless node.text == "Book"
-            node.parent.remove
+        @doc.xpath("//rss:item/dc:format").each do |element|
+          unless KNOWN_BOOK_FORMATS.include?(element.text)
+            element.parent.remove
           end
         end
       end

--- a/spec/fixtures/islington_library_query_results/three_items_incl_two_non_books.xml
+++ b/spec/fixtures/islington_library_query_results/three_items_incl_two_non_books.xml
@@ -56,6 +56,7 @@
     <rss:description>This is a fake book I am adding to the result, just so I can test that the non-book filtering works.</rss:description>
     <dc:creator>McAuthor, Authy, author.</dc:creator>
     <dcterms:language rdf:datatype="http://purl.org/dc/terms/ISO639-2">eng</dcterms:language>
+    <dc:format>Hardback</dc:format>
     <dc:format>Book</dc:format>
     <dc:publisher>UK: Del Rey, 2014</dc:publisher>
     <dc:date>2014</dc:date>

--- a/spec/library_assistant/islington_library/query_result_interpreter_spec.rb
+++ b/spec/library_assistant/islington_library/query_result_interpreter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe LibraryAssistant::IslingtonLibrary::QueryResultInterpreter do
 
     it "filters out non-book items" do
       expect(subject.instance_variable_get(:@doc).xpath("//rss:item").count).to eq(1)
-      expect(subject.instance_variable_get(:@doc).xpath("//rss:item/dc:format").text).to eq("Book")
+      expect(subject.instance_variable_get(:@doc).xpath("//rss:item/dc:format").text).to eq("HardbackBook")
     end
   end
 


### PR DESCRIPTION
...so that we don't accidentally filter out items we actually want.

I'd noticed that _Homegoing_ had gone missing from my web client's book grid, so I went Sherlocking.

Apparently _some_ query results come back with more than one `dc:format`, e.g.
```
    <dc:format>Hardback</dc:format>
    <dc:format>Book</dc:format>
```
^ As seen in the search for [_Homegoing_](https://capitadiscovery.co.uk/islington/items.rss?query=Homegoing%20Yaa%20Gyasi%20AND%20format%3A%28book%29).

There are still plenty of results that come with a single `<dc:format>Book</dc:format>`, e.g. [that _Martian_ search](https://capitadiscovery.co.uk/islington/items.rss?query=The%20Martian%20Andy%20Weir%20AND%20format%3A%28book%29) that's in the fixtures. 

I've done [a more general search](https://capitadiscovery.co.uk/islington/items.rss?query=Enlightenment+now) to see what `<dc:format>`s there are. So now in the `QueryResultInterpreter`, when filtering for book items, we check that the `<dc:format>` is "Book", "Hardback", "Paperback" or "Large print".